### PR TITLE
removido gitter do README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # NodeSchool Belo Horizonte :sunrise_over_mountains:
 
-[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/nodeschool/belo-horizonte?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+Saiba [mais no site](http://nodeschool.io/belo-horizonte) e [entre na conversa](https://github.com/nodeschool/belo-horizonte/issues)!
 
 ## Proximos Eventos
 * NodeGirls - 25 de Julho - Una Barro Preto - [nodegirls.com](http://nodegirls.com)
-
-Saiba [mais no site](http://nodeschool.io/belo-horizonte) e [entre na conversa](https://github.com/nodeschool/belo-horizonte/issues)!


### PR DESCRIPTION
Considerando que temos as [issues](https://github.com/nodeschool/belo-horizonte/issues) e o [Slack](https://nodeschoolbh.slack.com), será que não convém _descontinuar_ o [gitter](https://gitter.im/nodeschool/belo-horizonte)?
O que acham?

<sup>(1 é pouco, 2 é bom, 3 é demais?)</sup>
